### PR TITLE
feat: [sc-478107] Allow explicitly specifying gas limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ p8e {
             chainId = "pio-mainnet-1"
             mainNet = true
             txFeeAdjustment = "2.0"
+            fixedGasLimit = 60_000_000
             txBatchSize = "5"
             provenanceQueryTimeoutSeconds = "20"
             osHeaders = mapOf(

--- a/src/main/kotlin/com/figure/p8e/plugin/Bootstrapper.kt
+++ b/src/main/kotlin/com/figure/p8e/plugin/Bootstrapper.kt
@@ -2,7 +2,6 @@ package com.figure.p8e.plugin
 
 import com.google.protobuf.ByteString
 import com.google.protobuf.Message
-import io.grpc.ManagedChannelBuilder
 import io.provenance.client.grpc.BaseReqSigner
 import io.provenance.client.grpc.ChannelOpts
 import io.provenance.client.grpc.createChannel
@@ -127,7 +126,7 @@ internal class Bootstrapper(
 
         var errored = false
 
-        extension.locations.forEach { name, location ->
+        extension.locations.forEach { (name, location) ->
             project.logger.info("Publishing contracts - location: $name object-store url: ${location.osUrl} provenance url: ${location.provenanceUrl}")
 
             val config = ClientConfig(

--- a/src/main/kotlin/com/figure/p8e/plugin/Dsl.kt
+++ b/src/main/kotlin/com/figure/p8e/plugin/Dsl.kt
@@ -17,6 +17,7 @@ open class P8eLocationExtension {
     var mainNet: Boolean = chainId == "pio-mainnet-1"
     var txBatchSize: String = "10"
     var txFeeAdjustment: String = "1.25"
+    var fixedGasLimit: Long = 0
     var osHeaders: Map<String, String> = emptyMap()
 }
 


### PR DESCRIPTION
## Context

The default fee estimating logic sometimes fails when dealing with relatively larger specification updates. We can allow consumers to override the calculated gas limit.

## Changes

- Allow gas limit to be hardcoded to override what the message fee client would otherwise calculate
- Clean up a few code smells

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches transaction fee/gas estimation and broadcasting behavior; an incorrect fixed limit could cause tx failures or unintended fees when publishing specs.
> 
> **Overview**
> Adds a new `fixedGasLimit` configuration on `P8eLocationExtension`, documented in the README, to allow consumers to override the gas limit used for tx fee estimation.
> 
> Updates `ProvenanceClient` to use a custom gas estimator that still queries the msg-fee service for fees but applies the configured fixed limit when set; includes a small Kotlin destructuring cleanup in `Bootstrapper`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2427cc914bc061e0aa71a484ddd03ece1dc70ef1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->