### PR TITLE
feat: Support for fee granter

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ p8e {
             chainId: System.getenv('CHAIN_ID'),
             encryptionPrivateKey: System.getenv('ENCRYPTION_PRIVATE_KEY'),
             signingPrivateKey: System.getenv('SIGNING_PRIVATE_KEY'),
+            feeGranterAddress: System.getenv('FEE_GRANTER_ADDRESS'),
             txBatchSize: "10",
             osHeaders: [
                 // optional object store grpc headers here
@@ -137,6 +138,7 @@ p8e {
             provenanceUrl = System.getenv("PROVENANCE_GRPC_URL")
             encryptionPrivateKey = System.getenv("ENCRYPTION_PRIVATE_KEY")
             signingPrivateKey = System.getenv("SIGNING_PRIVATE_KEY")
+            feeGranterAddress = System.getenv("FEE_GRANTER_ADDRESS")
             chainId = "pio-mainnet-1"
             mainNet = true
             txFeeAdjustment = "2.0"

--- a/src/main/kotlin/com/figure/p8e/plugin/Dsl.kt
+++ b/src/main/kotlin/com/figure/p8e/plugin/Dsl.kt
@@ -18,6 +18,7 @@ open class P8eLocationExtension {
     var txBatchSize: String = "10"
     var txFeeAdjustment: String = "1.25"
     var fixedGasLimit: Long = 0
+    var feeGranterAddress: String? = null
     var osHeaders: Map<String, String> = emptyMap()
 }
 

--- a/src/main/kotlin/com/figure/p8e/plugin/ProvenanceClient.kt
+++ b/src/main/kotlin/com/figure/p8e/plugin/ProvenanceClient.kt
@@ -66,6 +66,7 @@ class ProvenanceClient(channel: ManagedChannel, val logger: Logger, val location
                 signers = listOf(signer),
                 mode = BroadcastMode.BROADCAST_MODE_BLOCK, // faux block, will poll in background
                 gasAdjustment = location.txFeeAdjustment.toDouble(),
+                feeGranter = location.feeGranterAddress?.takeIf { it.isNotBlank() },
                 txHashHandler = { logger.trace("Preparing to broadcast $it") }
             )
 


### PR DESCRIPTION
Adding support for specifying a fee granter for paying for bootstrap transactions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches transaction broadcast parameters by introducing an optional fee granter, which can change fee payment behavior and cause tx failures if misconfigured. Scope is small and gated behind a nullable/blank check.
> 
> **Overview**
> Adds support for specifying a *fee granter* address in the plugin configuration (`P8eLocationExtension.feeGranterAddress`).
> 
> When present and non-blank, this value is forwarded to `PbClient.estimateAndBroadcastTx` as `feeGranter` so bootstrap/broadcasted transactions can have fees paid by the configured granter. Documentation examples in `README.md` are updated to show `FEE_GRANTER_ADDRESS` usage in both Groovy and Kotlin DSLs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c9e2cbfbfead26ff77353eb6d488460efd1320e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->