### PR TITLE
fix: [sc-525275] relocate io.grpc in the shadow jar

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -86,6 +86,14 @@ tasks.withType<KotlinCompile> {
 tasks.withType<ShadowJar> {
     archiveClassifier.set("")
     isZip64 = true
+
+    // Merge duplicate META-INF/services entries from embedded gRPC jars.
+    // Without this, LoadBalancerProvider SPI can be emptied/overwritten in the fat jar.
+    mergeServiceFiles()
+
+    // Relocate gRPC so Gradle 9 plugin-classpath instrumentation / parent classloaders
+    // cannot mix unshaded io.grpc from this fat jar with other plugins (FGP, GAR, etc.).
+    relocate("io.grpc", "com.figure.p8e.shaded.io.grpc")
 }
 
 tasks.withType<Test> {


### PR DESCRIPTION
<!-- READ THE README BEFORE YOU CREATE A PULL REQUEST and ensure your PR is tagged properly -->

## Context
<!--
    Describe
    - the problem
    - use cases
    - possible solutions
    - explanation of decisions made
    And include links to relevant issues & references
-->
After migrating consumers (e.g. `los-p8e-contracts`) to FGP v6 / Gradle 9, `:p8eBootstrap` fails with gRPC classloader errors (`ClassNotFoundException: PickFirstLoadBalancerProvider`, `NoSuchMethodError: LoadBalancer.acceptResolvedAddresses)`.

**Root cause:** this plugin publishes a Shadow fat jar with unrelocated `io.grpc.*`. Gradle 9 instruments that jar on the plugin classpath and can mix it with other plugins’ gRPC (FGP/GAR), which breaks LoadBalancer SPI / API compatibility. Develop on Gradle 8 + FGP 4 is unaffected; latest published plugin is still `1.2.0`.

**Fix:** relocate embedded gRPC inside the Shadow jar and merge duplicate META-INF/services entries so bootstrap uses an isolated gRPC copy.

## Changes
<!-- List the changes made -->
- Add `mergeServiceFiles()` to the ShadowJar task
- Relocate `io.grpc` → `com.figure.p8e.shaded.io.grpc` in the published fat jar

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how the published fat jar packages and loads gRPC, which affects all Gradle 9 consumers of bootstrap but is limited to build/packaging rather than contract logic.
> 
> **Overview**
> Fixes **Gradle 9 / FGP v6** failures in `:p8eBootstrap` (`PickFirstLoadBalancerProvider`, `LoadBalancer.acceptResolvedAddresses`) caused by an unshaded `io.grpc` fat jar colliding with other plugins’ gRPC on the instrumented plugin classpath.
> 
> The **ShadowJar** task now calls **`mergeServiceFiles()`** so embedded gRPC jars don’t clobber **`META-INF/services`** entries (LoadBalancer SPI), and **`relocate("io.grpc", "com.figure.p8e.shaded.io.grpc")`** so this plugin’s embedded gRPC stays isolated from FGP/GAR and parent classloaders.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 513c53a4eebddd9acd272484ad196ce471ea7d1d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->